### PR TITLE
update cli for provider start and stop feature

### DIFF
--- a/cmd/vt/main.go
+++ b/cmd/vt/main.go
@@ -4,9 +4,7 @@ import (
 	"github.com/happyhackingspace/vulnerable-target/internal/cli"
 	"github.com/happyhackingspace/vulnerable-target/internal/logger"
 	"github.com/happyhackingspace/vulnerable-target/pkg/options"
-	"github.com/happyhackingspace/vulnerable-target/pkg/provider/registry"
 	"github.com/happyhackingspace/vulnerable-target/pkg/templates"
-	"github.com/rs/zerolog/log"
 )
 
 func init() {
@@ -17,13 +15,4 @@ func init() {
 
 func main() {
 	cli.Execute()
-	options := options.GetOptions()
-	provider := registry.GetProvider(options.ProviderName)
-	if provider == nil {
-		log.Fatal().Msgf("provider %s not found", options.ProviderName)
-	}
-	if err := provider.Start(); err != nil {
-		log.Fatal().Msgf("%v", err)
-	}
-	log.Info().Msgf("%s template is running on %s", options.TemplateID, options.ProviderName)
 }

--- a/cmd/vt/main.go
+++ b/cmd/vt/main.go
@@ -14,5 +14,5 @@ func init() {
 }
 
 func main() {
-	cli.Execute()
+	cli.Run()
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -8,7 +8,7 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all available templates with descriptions",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		templates.List()
 	},
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"github.com/happyhackingspace/vulnerable-target/pkg/templates"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all available templates with descriptions",
+	Run: func(cmd *cobra.Command, args []string) {
+		templates.List()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,14 +3,11 @@ package cli
 import (
 	"fmt"
 	"maps"
-	"os"
 	"slices"
 	"strings"
 
 	"github.com/happyhackingspace/vulnerable-target/internal/logger"
 	"github.com/happyhackingspace/vulnerable-target/pkg/options"
-	"github.com/happyhackingspace/vulnerable-target/pkg/provider/registry"
-	"github.com/happyhackingspace/vulnerable-target/pkg/templates"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -29,20 +26,9 @@ var LogLevels = map[string]bool{
 func init() {
 	options := options.GetOptions()
 
-	rootCmd.Flags().BoolP("version", "V", false, "Show the current version of the tool")
-
-	rootCmd.Flags().StringVarP(&options.VerbosityLevel, "verbosity", "v", zerolog.InfoLevel.String(),
+	rootCmd.PersistentFlags().StringVarP(&options.VerbosityLevel, "verbosity", "v", zerolog.InfoLevel.String(),
 		fmt.Sprintf("Set the verbosity level for logs (%s)",
 			strings.Join(slices.Collect(maps.Keys(LogLevels)), ", ")))
-
-	rootCmd.Flags().BoolP("list-templates", "l", false, "List all available templates with descriptions")
-
-	rootCmd.Flags().StringVarP(&options.ProviderName, "provider", "p", "",
-		fmt.Sprintf("Specify the cloud provider for building a vulnerable environment (%s)",
-			strings.Join(slices.Collect(maps.Keys(registry.Providers)), ", ")))
-
-	rootCmd.Flags().StringVar(&options.TemplateID, "id", "",
-		"Specify a template ID for targeted vulnerable environment")
 }
 
 var rootCmd = &cobra.Command{
@@ -53,51 +39,6 @@ var rootCmd = &cobra.Command{
 		logger.Init()
 	},
 	SilenceErrors: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		options := options.GetOptions()
-
-		if len(args) == 0 && cmd.Flags().NFlag() == 0 {
-			if err := cmd.Help(); err != nil {
-				log.Fatal().Msgf("Error displaying help: %v\n", err)
-			}
-			os.Exit(0)
-			return
-		}
-
-		listTemplates, err := cmd.Flags().GetBool("list-templates")
-		if err != nil {
-			log.Fatal().Msgf("Error getting list-templates flag: %v", err)
-		}
-		if listTemplates {
-			templates.List()
-			os.Exit(0)
-			return
-		}
-
-		if !LogLevels[options.VerbosityLevel] {
-			log.Fatal().Msgf("invalid provider '%s'. Valid providers are: %s",
-				options.VerbosityLevel,
-				strings.Join(slices.Collect(maps.Keys(LogLevels)), ", "))
-		}
-
-		if options.ProviderName == "" {
-			log.Fatal().Msgf("provider is required")
-		}
-
-		if _, ok := registry.Providers[options.ProviderName]; !ok {
-			log.Fatal().Msgf("invalid provider '%s'. Valid providers are: %s",
-				options.ProviderName,
-				strings.Join(slices.Collect(maps.Keys(registry.Providers)), ", "))
-		}
-
-		if options.TemplateID == "" {
-			log.Fatal().Msgf("template is required")
-		} else {
-			if _, ok := templates.Templates[options.TemplateID]; !ok {
-				log.Fatal().Msg("there is no template given id")
-			}
-		}
-	},
 }
 
 func Execute() {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -41,7 +41,7 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 }
 
-func Execute() {
+func Run() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal().Msg(err.Error())
 	}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/happyhackingspace/vulnerable-target/pkg/options"
+	"github.com/happyhackingspace/vulnerable-target/pkg/provider/registry"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Runs selected template on chosen provider",
+	Run: func(cmd *cobra.Command, args []string) {
+		options := options.GetOptions()
+		provider := registry.GetProvider(options.ProviderName)
+		if len(options.TemplateID) == 0 || len(options.ProviderName) == 0 {
+			err := cmd.Help()
+			if err != nil {
+				log.Fatal().Msgf("%v", err)
+			}
+			return
+		}
+		if provider == nil {
+			log.Fatal().Msgf("provider %s not found", options.ProviderName)
+		}
+		if err := provider.Start(); err != nil {
+			log.Fatal().Msgf("%v", err)
+		}
+		log.Info().Msgf("%s template is running on %s", options.TemplateID, options.ProviderName)
+	},
+}
+
+func init() {
+	options := options.GetOptions()
+
+	rootCmd.AddCommand(startCmd)
+
+	startCmd.Flags().StringVarP(&options.ProviderName, "provider", "p", "",
+		fmt.Sprintf("Specify the provider for building a vulnerable environment (%s)",
+			strings.Join(slices.Collect(maps.Keys(registry.Providers)), ", ")))
+
+	startCmd.Flags().StringVar(&options.TemplateID, "id", "",
+		"Specify a template ID for targeted vulnerable environment")
+}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/happyhackingspace/vulnerable-target/pkg/options"
 	"github.com/happyhackingspace/vulnerable-target/pkg/provider/registry"
+	"github.com/happyhackingspace/vulnerable-target/pkg/templates"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -28,9 +29,17 @@ var startCmd = &cobra.Command{
 		if provider == nil {
 			log.Fatal().Msgf("provider %s not found", options.ProviderName)
 		}
-		if err := provider.Start(); err != nil {
+
+		template, err := templates.GetCurrentTemplate()
+		if err != nil {
 			log.Fatal().Msgf("%v", err)
 		}
+
+		err = provider.Start(template)
+		if err != nil {
+			log.Fatal().Msgf("%v", err)
+		}
+
 		log.Info().Msgf("%s template is running on %s", options.TemplateID, options.ProviderName)
 	},
 }

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -15,7 +15,7 @@ import (
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Runs selected template on chosen provider",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		options := options.GetOptions()
 		provider := registry.GetProvider(options.ProviderName)
 		if len(options.TemplateID) == 0 || len(options.ProviderName) == 0 {

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -30,7 +30,7 @@ var startCmd = &cobra.Command{
 			log.Fatal().Msgf("provider %s not found", options.ProviderName)
 		}
 
-		template, err := templates.GetCurrentTemplate()
+		template, err := templates.GetById(options.TemplateID)
 		if err != nil {
 			log.Fatal().Msgf("%v", err)
 		}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -30,7 +30,7 @@ var startCmd = &cobra.Command{
 			log.Fatal().Msgf("provider %s not found", options.ProviderName)
 		}
 
-		template, err := templates.GetById(options.TemplateID)
+		template, err := templates.GetByID(options.TemplateID)
 		if err != nil {
 			log.Fatal().Msgf("%v", err)
 		}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -15,7 +15,7 @@ import (
 var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop vulnerable enviroment by template id and provider",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		options := options.GetOptions()
 		provider := registry.GetProvider(options.ProviderName)
 		if len(options.TemplateID) == 0 || len(options.ProviderName) == 0 {

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/happyhackingspace/vulnerable-target/pkg/options"
+	"github.com/happyhackingspace/vulnerable-target/pkg/provider/registry"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop vulnerable enviroment by template id and provider",
+	Run: func(cmd *cobra.Command, args []string) {
+		options := options.GetOptions()
+		provider := registry.GetProvider(options.ProviderName)
+		if len(options.TemplateID) == 0 || len(options.ProviderName) == 0 {
+			err := cmd.Help()
+			if err != nil {
+				log.Fatal().Msgf("%v", err)
+			}
+			return
+		}
+		if provider == nil {
+			log.Fatal().Msgf("provider %s not found", options.ProviderName)
+		}
+		if err := provider.Stop(); err != nil {
+			log.Fatal().Msgf("%v", err)
+		}
+		log.Info().Msgf("%s template stopped on %s", options.TemplateID, options.ProviderName)
+	},
+}
+
+func init() {
+	options := options.GetOptions()
+
+	rootCmd.AddCommand(stopCmd)
+
+	stopCmd.Flags().StringVarP(&options.ProviderName, "provider", "p", "",
+		fmt.Sprintf("Specify the provider for building a vulnerable environment (%s)",
+			strings.Join(slices.Collect(maps.Keys(registry.Providers)), ", ")))
+
+	stopCmd.Flags().StringVar(&options.TemplateID, "id", "",
+		"Specify a template ID for targeted vulnerable environment")
+}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -30,7 +30,7 @@ var stopCmd = &cobra.Command{
 			log.Fatal().Msgf("provider %s not found", options.ProviderName)
 		}
 
-		template, err := templates.GetById(options.TemplateID)
+		template, err := templates.GetByID(options.TemplateID)
 		if err != nil {
 			log.Fatal().Msgf("%v", err)
 		}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/happyhackingspace/vulnerable-target/pkg/options"
 	"github.com/happyhackingspace/vulnerable-target/pkg/provider/registry"
+	"github.com/happyhackingspace/vulnerable-target/pkg/templates"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
 var stopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stop vulnerable enviroment by template id and provider",
+	Short: "Stop vulnerable environment by template id and provider",
 	Run: func(cmd *cobra.Command, _ []string) {
 		options := options.GetOptions()
 		provider := registry.GetProvider(options.ProviderName)
@@ -28,9 +29,17 @@ var stopCmd = &cobra.Command{
 		if provider == nil {
 			log.Fatal().Msgf("provider %s not found", options.ProviderName)
 		}
-		if err := provider.Stop(); err != nil {
+
+		template, err := templates.GetCurrentTemplate()
+		if err != nil {
 			log.Fatal().Msgf("%v", err)
 		}
+
+		err = provider.Stop(template)
+		if err != nil {
+			log.Fatal().Msgf("%v", err)
+		}
+
 		log.Info().Msgf("%s template stopped on %s", options.TemplateID, options.ProviderName)
 	},
 }

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -30,7 +30,7 @@ var stopCmd = &cobra.Command{
 			log.Fatal().Msgf("provider %s not found", options.ProviderName)
 		}
 
-		template, err := templates.GetCurrentTemplate()
+		template, err := templates.GetById(options.TemplateID)
 		if err != nil {
 			log.Fatal().Msgf("%v", err)
 		}

--- a/internal/file/utils.go
+++ b/internal/file/utils.go
@@ -24,6 +24,6 @@ func CreateTempFile(content string, name string) (string, error) {
 	return filePath, nil
 }
 
-func DeteleFile(path string) error {
+func DeleteFile(path string) error {
 	return os.RemoveAll(path)
 }

--- a/internal/file/utils.go
+++ b/internal/file/utils.go
@@ -7,7 +7,7 @@ import (
 )
 
 func CreateTempFile(content string, name string) (string, error) {
-	tempDir := filepath.Join(os.TempDir(), "vt-file")
+	tempDir := filepath.Join(os.TempDir(), "vt-folder")
 
 	err := os.MkdirAll(tempDir, 0700)
 	if err != nil {
@@ -22,4 +22,8 @@ func CreateTempFile(content string, name string) (string, error) {
 	}
 
 	return filePath, nil
+}
+
+func DeteleFile(path string) error {
+	return os.RemoveAll(path)
 }

--- a/pkg/provider/dockercompose/dockercompose.go
+++ b/pkg/provider/dockercompose/dockercompose.go
@@ -18,12 +18,7 @@ func (d *DockerCompose) Name() string {
 	return "docker-compose"
 }
 
-func (d *DockerCompose) Start() error {
-	template, err := templates.GetCurrentTemplate()
-	if err != nil {
-		return err
-	}
-
+func (d *DockerCompose) Start(template *templates.Template) error {
 	composeContent := template.Providers["docker_compose"].Content
 
 	composeFilePath, err := file.CreateTempFile(composeContent, "docker-compose.yml")
@@ -40,7 +35,7 @@ func (d *DockerCompose) Start() error {
 		return err
 	}
 
-	err = file.DeteleFile(composeFilePath)
+	err = file.DeleteFile(composeFilePath)
 	if err != nil {
 		return err
 	}
@@ -48,12 +43,7 @@ func (d *DockerCompose) Start() error {
 	return nil
 }
 
-func (d *DockerCompose) Stop() error {
-	template, err := templates.GetCurrentTemplate()
-	if err != nil {
-		return err
-	}
-
+func (d *DockerCompose) Stop(template *templates.Template) error {
 	composeContent := template.Providers["docker_compose"].Content
 
 	composeFilePath, err := file.CreateTempFile(composeContent, "docker-compose.yml")
@@ -70,7 +60,7 @@ func (d *DockerCompose) Stop() error {
 		return err
 	}
 
-	err = file.DeteleFile(composeFilePath)
+	err = file.DeleteFile(composeFilePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,7 +1,9 @@
 package provider
 
+import "github.com/happyhackingspace/vulnerable-target/pkg/templates"
+
 type Provider interface {
 	Name() string
-	Start() error
-	Stop() error
+	Start(template *templates.Template) error
+	Stop(template *templates.Template) error
 }

--- a/pkg/templates/template.go
+++ b/pkg/templates/template.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/happyhackingspace/vulnerable-target/pkg/options"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rs/zerolog/log"
 )
@@ -77,11 +76,10 @@ func List() {
 	t.Render()
 }
 
-func GetCurrentTemplate() (*Template, error) {
-	options := options.GetOptions()
-	template := Templates[options.TemplateID]
+func GetById(templateID string) (*Template, error) {
+	template := Templates[templateID]
 	if template.ID == "" {
-		return nil, fmt.Errorf("template %s not found", options.TemplateID)
+		return nil, fmt.Errorf("template %s not found", templateID)
 	}
 	return &template, nil
 }

--- a/pkg/templates/template.go
+++ b/pkg/templates/template.go
@@ -1,10 +1,12 @@
 package templates
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strings"
 
+	"github.com/happyhackingspace/vulnerable-target/pkg/options"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rs/zerolog/log"
 )
@@ -73,4 +75,13 @@ func List() {
 	t.SetCaption("there are %d templates", len(Templates))
 	t.SetIndexColumn(0)
 	t.Render()
+}
+
+func GetCurrentTemplate() (*Template, error) {
+	options := options.GetOptions()
+	template := Templates[options.TemplateID]
+	if template.ID == "" {
+		return nil, fmt.Errorf("template %s not found", options.TemplateID)
+	}
+	return &template, nil
 }

--- a/pkg/templates/template.go
+++ b/pkg/templates/template.go
@@ -76,7 +76,7 @@ func List() {
 	t.Render()
 }
 
-func GetById(templateID string) (*Template, error) {
+func GetByID(templateID string) (*Template, error) {
 	template := Templates[templateID]
 	if template.ID == "" {
 		return nil, fmt.Errorf("template %s not found", templateID)


### PR DESCRIPTION
## Description
Fixes [ensure docker-compose provider is working as expected](https://github.com/HappyHackingSpace/vulnerable-target/issues/24)

## Related Issue
Fixes [24](https://github.com/HappyHackingSpace/vulnerable-target/issues/24)

## Changes Made
Add command in cli for managing up or down an env
Add delete function to remove temp file

## Checklist
- [ ] Documentation updated
- [X] Code follows project style guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new CLI commands: `list` (lists available templates), `start` (runs a selected template on a specified provider), and `stop` (stops a running environment).
- **Improvements**
  - Enhanced error handling and messaging for provider and template selection in CLI commands.
  - Improved cleanup by ensuring temporary files are deleted after Docker Compose operations.
  - Added centralized retrieval of templates by ID with validation.
- **Bug Fixes**
  - Stopping environments now also removes associated Docker volumes.
- **Chores**
  - Simplified CLI flag management and internal command structure for better usability.
  - Refined CLI root command by removing deprecated flags and runtime validations.
  - Updated CLI execution flow to streamline command handling.
  - Removed legacy CLI execution logic for streamlined command processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->