### PR TITLE
images moved to ghrc.io

### DIFF
--- a/templates/bwapp/docker-compose.yaml
+++ b/templates/bwapp/docker-compose.yaml
@@ -2,7 +2,7 @@
 
 services:
   web:
-    image: hackersploit/bwapp-docker:latest
+    image: ghcr.io/happyhackingspace/bwapp
     ports:
       - "80:80"
     networks:

--- a/templates/juice-shop/docker-compose.yaml
+++ b/templates/juice-shop/docker-compose.yaml
@@ -2,7 +2,7 @@
 
 services:
   web:
-    image: bkimminich/juice-shop:latest
+    image: ghcr.io/happyhackingspace/juice-shop:latest
     ports:
       - "3000:3000"
     environment:

--- a/templates/mutillidae-ii/docker-compose.yaml
+++ b/templates/mutillidae-ii/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
     ports:
       - 127.0.0.1:82:80
     networks:
-      - ldapnet 
+      - ldapnet
 
 volumes:
   ldap_data:

--- a/templates/mutillidae-ii/docker-compose.yaml
+++ b/templates/mutillidae-ii/docker-compose.yaml
@@ -2,14 +2,14 @@
 
 services:
   database:
-    image: docker.io/webpwnized/mutillidae:database
+    image: ghcr.io/happyhackingspace/mutillidae-database:latest
     networks:
       - datanet
 
   database_admin:
     depends_on:
       - database
-    image: docker.io/webpwnized/mutillidae:database_admin
+    image: ghcr.io/happyhackingspace/mutillidae-database_admin:latest
     ports:
       - 127.0.0.1:81:80
     networks:
@@ -19,7 +19,7 @@ services:
     depends_on:
       - database
       - directory
-    image: docker.io/webpwnized/mutillidae:www
+    image: ghcr.io/happyhackingspace/mutillidae-www:latest
     ports:
       - 127.0.0.1:80:80
       - 127.0.0.1:443:443
@@ -28,7 +28,7 @@ services:
       - ldapnet
 
   directory:
-    image: docker.io/webpwnized/mutillidae:ldap
+    image: ghcr.io/happyhackingspace/mutillidae-ldap:latest
     volumes:
       - ldap_data:/var/lib/ldap
       - ldap_config:/etc/ldap/slapd.d
@@ -40,11 +40,11 @@ services:
   directory_admin:
     depends_on:
       - directory
-    image: docker.io/webpwnized/mutillidae:ldap_admin
+    image: ghcr.io/happyhackingspace/mutillidae-ldap_admin:latest
     ports:
       - 127.0.0.1:82:80
     networks:
-      - ldapnet
+      - ldapnet 
 
 volumes:
   ldap_data:

--- a/templates/web-dvwa/docker-compose.yaml
+++ b/templates/web-dvwa/docker-compose.yaml
@@ -2,7 +2,7 @@
 
 services:
   web:
-    image: vulnerables/web-dvwa:latest
+    image: ghcr.io/happyhackingspace/web-dvwa
     ports:
       - "80:80"
     environment:

--- a/templates/webgoat/docker-compose.yaml
+++ b/templates/webgoat/docker-compose.yaml
@@ -2,7 +2,7 @@
 
 services:
   webgoat:
-    image: webgoat/webgoat:latest
+    image: ghcr.io/happyhackingspace/webgoat:latest
     ports:
       - "8080:8080"
       - "9090:9090"


### PR DESCRIPTION
## Description
<!-- Briefly describe what this PR does -->

## Related Issue
<!-- Link to the issue this PR resolves, if applicable -->
Fixes #

## Changes Made
<!-- List the main changes made in this PR -->

## Checklist
- [x] Documentation updated
- [x] Code follows project style guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container images for security lab templates to a new registry for:
    - bWAPP, OWASP Juice Shop, Mutillidae II (database, database admin, www, LDAP, LDAP admin), DVWA, WebGoat
  * No changes to ports, environment variables, volumes, or networks; existing workflows remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->