### PR TITLE
feat: Add new vulnerability template for CVE-2024-53995  

### DIFF
--- a/templates/vt-2024-53995/docker-compose.yaml
+++ b/templates/vt-2024-53995/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  sickchill:
+    image: ghcr.io/happyhackingspace/sickchill:2024.3.1
+    container_name: sickchill
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+    environment:
+      - TZ=Europe/Istanbul

--- a/templates/vt-2024-53995/index.yaml
+++ b/templates/vt-2024-53995/index.yaml
@@ -1,0 +1,40 @@
+---
+id: vt-2024-53995
+
+info:
+  name: "SickChill Login - Open Redirect"
+  author: omarkurt
+  description: |
+    SickChill contains an open redirect vulnerability on the login page. An attacker can redirect a user to a malicious site via the 'next' parameter.
+  targets:
+    - "python"
+    - "media server"
+  type: CVE
+  affected_versions:
+    - "2024.3.1"
+  fixed_version: "latest"
+  cve: "CVE-2024-53995"
+  cwe: "CWE-601"
+  cvss:
+    score: "1.9"
+    metrics: "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+  tags:
+    - "open-redirect"
+    - "cve"
+    - "redirect"
+  references:
+    - https://github.com/SickChill/sickchill/blob/846adafdfab579281353ea08a27bbb813f9a9872/sickchill/views/authentication.py#L33
+    - https://github.com/SickChill/sickchill/commit/c7128a8946c3701df95c285810eb75b2de18bf82
+    - https://github.com/SickChill/sickchill/pull/8811
+    - https://securitylab.github.com/advisories/GHSL-2024-283_GHSL-2024-291_sickchill_sickchill/
+    - https://vulnerabletarget.com/VT-2024-53995
+
+poc:
+  nuclei:
+    - "vt-2024-53995.nuclei.yaml"
+  semgrep:
+    - "vt-2024-53995.semgrep"
+
+providers:
+  docker-compose:
+    path: "docker-compose.yaml"

--- a/templates/vt-2024-53995/vt-2024-53995.nuclei.yaml
+++ b/templates/vt-2024-53995/vt-2024-53995.nuclei.yaml
@@ -1,0 +1,36 @@
+id: sickchill-login-open-redirect
+
+info:
+  name: SickChill Login - Open Redirect
+  author: omarkurt
+  severity: low
+  description: |
+    SickChill contains an open redirect vulnerability on the login page. An attacker can redirect a user to a malicious site via the 'next' parameter.
+  reference:
+    - https://securitylab.github.com/advisories/GHSL-2024-283_GHSL-2024-291_sickchill_sickchill/
+    - https://vulnerabletarget.com/VT-2024-53995
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 1.9
+    cwe-id: CWE-601
+  metadata:
+    max-request: 1
+    shodan-query: title:"SickChill Login - Open Redirect"
+  tags: python,open-redirect,cve,redirect,vuln
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/login/?next=https://vulnerabletarget.com"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(location, "vulnerabletarget.com")'
+      - type: status
+        status:
+          - 302

--- a/templates/vt-2024-53995/vt-2024-53995.semgrep
+++ b/templates/vt-2024-53995/vt-2024-53995.semgrep
@@ -1,0 +1,35 @@
+rules:
+  - id: sickchill-cve-2024-53995-open-redirect
+    mode: search
+    message: >-
+      SickChill Open Redirect vulnerability detected. An attacker can redirect a 
+      user to a malicious site via the 'next' parameter in the login page.
+      
+      This issue is tracked as CVE-2024-53995.
+    languages:
+      - python
+    severity: ERROR
+    metadata:
+      category: security
+      cwe:
+        - "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
+      owasp:
+        - "A01:2021 - Broken Access Control"
+      references:
+        - https://www.cve.org/CVERecord?id=CVE-2024-53995
+        - https://github.com/SickChill/SickChill
+      subcategory:
+        - vuln
+      technology:
+        - python
+        - sickchill
+        - web
+      vulnerability_class:
+        - Open Redirect
+      author: omarkurt
+
+    patterns:
+      - pattern: |
+          $VAR = self.get_query_argument("next", ...)
+          ...
+          self.redirect($VAR or ...)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection templates for SickChill CVE-2024-53995, a login open redirect vulnerability. Includes scanning rules and a containerized environment for identifying vulnerable instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->