### PR TITLE
refactor: rename module from vulnerable-target to vt

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 ### Install with Go
 
 ```bash
-go install github.com/happyhackingspace/vulnerable-target/cmd/vt@latest
+go install github.com/happyhackingspace/vt/cmd/vt@latest
 ```
 
 ### Build from Source

--- a/cmd/vt/main.go
+++ b/cmd/vt/main.go
@@ -2,13 +2,13 @@
 package main
 
 import (
-	"github.com/happyhackingspace/vulnerable-target/internal/app"
-	"github.com/happyhackingspace/vulnerable-target/internal/cli"
-	"github.com/happyhackingspace/vulnerable-target/internal/logger"
-	"github.com/happyhackingspace/vulnerable-target/internal/state"
-	"github.com/happyhackingspace/vulnerable-target/pkg/provider/registry"
-	"github.com/happyhackingspace/vulnerable-target/pkg/store/disk"
-	"github.com/happyhackingspace/vulnerable-target/pkg/template"
+	"github.com/happyhackingspace/vt/internal/app"
+	"github.com/happyhackingspace/vt/internal/cli"
+	"github.com/happyhackingspace/vt/internal/logger"
+	"github.com/happyhackingspace/vt/internal/state"
+	"github.com/happyhackingspace/vt/pkg/provider/registry"
+	"github.com/happyhackingspace/vt/pkg/store/disk"
+	"github.com/happyhackingspace/vt/pkg/template"
 	"github.com/rs/zerolog/log"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/happyhackingspace/vulnerable-target
+module github.com/happyhackingspace/vt
 
 go 1.24.0
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/happyhackingspace/vulnerable-target/internal/state"
-	"github.com/happyhackingspace/vulnerable-target/pkg/provider"
-	"github.com/happyhackingspace/vulnerable-target/pkg/template"
+	"github.com/happyhackingspace/vt/internal/state"
+	"github.com/happyhackingspace/vt/pkg/provider"
+	"github.com/happyhackingspace/vt/pkg/template"
 )
 
 // Config holds application configuration.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,9 +7,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/happyhackingspace/vulnerable-target/internal/app"
-	"github.com/happyhackingspace/vulnerable-target/internal/banner"
-	"github.com/happyhackingspace/vulnerable-target/internal/logger"
+	"github.com/happyhackingspace/vt/internal/app"
+	"github.com/happyhackingspace/vt/internal/banner"
+	"github.com/happyhackingspace/vt/internal/logger"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	templ "github.com/happyhackingspace/vulnerable-target/pkg/template"
+	templ "github.com/happyhackingspace/vt/pkg/template"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	tmpl "github.com/happyhackingspace/vulnerable-target/pkg/template"
+	tmpl "github.com/happyhackingspace/vt/pkg/template"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	tmpl "github.com/happyhackingspace/vulnerable-target/pkg/template"
+	tmpl "github.com/happyhackingspace/vt/pkg/template"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	tmpl "github.com/happyhackingspace/vulnerable-target/pkg/template"
+	tmpl "github.com/happyhackingspace/vt/pkg/template"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	tmpl "github.com/happyhackingspace/vulnerable-target/pkg/template"
+	tmpl "github.com/happyhackingspace/vt/pkg/template"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/happyhackingspace/vulnerable-target/pkg/store"
+	"github.com/happyhackingspace/vt/pkg/store"
 )
 
 // Deployment represents the status of an environment on a specified provider

--- a/pkg/provider/dockercompose/dockercompose.go
+++ b/pkg/provider/dockercompose/dockercompose.go
@@ -4,9 +4,9 @@ package dockercompose
 import (
 	"fmt"
 
-	"github.com/happyhackingspace/vulnerable-target/internal/state"
-	"github.com/happyhackingspace/vulnerable-target/pkg/provider"
-	tmpl "github.com/happyhackingspace/vulnerable-target/pkg/template"
+	"github.com/happyhackingspace/vt/internal/state"
+	"github.com/happyhackingspace/vt/pkg/provider"
+	tmpl "github.com/happyhackingspace/vt/pkg/template"
 )
 
 var _ provider.Provider = &DockerCompose{}

--- a/pkg/provider/dockercompose/utils.go
+++ b/pkg/provider/dockercompose/utils.go
@@ -15,8 +15,8 @@ import (
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/compose"
-	"github.com/happyhackingspace/vulnerable-target/internal/app"
-	tmpl "github.com/happyhackingspace/vulnerable-target/pkg/template"
+	"github.com/happyhackingspace/vt/internal/app"
+	tmpl "github.com/happyhackingspace/vt/pkg/template"
 )
 
 func createDockerCLI() (command.Cli, error) {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -2,7 +2,7 @@
 package provider
 
 import (
-	tmpl "github.com/happyhackingspace/vulnerable-target/pkg/template"
+	tmpl "github.com/happyhackingspace/vt/pkg/template"
 )
 
 // Provider defines the interface for managing vulnerable target environments.

--- a/pkg/provider/registry/registry.go
+++ b/pkg/provider/registry/registry.go
@@ -2,9 +2,9 @@
 package registry
 
 import (
-	"github.com/happyhackingspace/vulnerable-target/internal/state"
-	"github.com/happyhackingspace/vulnerable-target/pkg/provider"
-	"github.com/happyhackingspace/vulnerable-target/pkg/provider/dockercompose"
+	"github.com/happyhackingspace/vt/internal/state"
+	"github.com/happyhackingspace/vt/pkg/provider"
+	"github.com/happyhackingspace/vt/pkg/provider/dockercompose"
 )
 
 // NewProviders creates and returns a map of all available providers.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -4,7 +4,7 @@ package store
 import (
 	"errors"
 
-	"github.com/happyhackingspace/vulnerable-target/pkg/store/disk"
+	"github.com/happyhackingspace/vt/pkg/store/disk"
 )
 
 // Type represents the type of storage backend


### PR DESCRIPTION
## Summary
- Renamed Go module path from `github.com/happyhackingspace/vulnerable-target` to `github.com/happyhackingspace/vt`
- Updated all import statements across 15 Go files
- Updated README go install path

## Reason
Module name should match the repository name for consistency and correct `go install` behavior.

## Test Plan
- [x] `go mod tidy` passes
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)