### PR TITLE
chore: enable Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary
- Enable Dependabot for automated dependency updates
- Configure weekly updates for Go modules (`gomod`)
- Configure weekly updates for GitHub Actions
- Set commit message prefix to `chore(deps)` for consistency

Closes #108