### PR TITLE
fix: remove draft releases

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,10 +74,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Create draft release
+      - name: Create release
         run: |
           if ! gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
-            gh release create "${GITHUB_REF_NAME}" --draft --generate-notes
+            gh release create "${GITHUB_REF_NAME}" --generate-notes
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -187,19 +187,5 @@ jobs:
             vt_${VERSION}_macOS_*.zip \
             "vt_${VERSION}_macOS_checksums.txt" \
             --clobber
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-release:
-    name: "🚀 Publish Release"
-    needs: [release-linux, release-windows, release-darwin]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Publish release
-        run: gh release edit "${GITHUB_REF_NAME}" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `--draft` flag (immutable releases disabled)
- Remove `publish-release` job (no longer needed)